### PR TITLE
Mostrar nombre completo en asignación y bloquear reasignación

### DIFF
--- a/tareas_app/models.py
+++ b/tareas_app/models.py
@@ -37,6 +37,18 @@ class Empleado(models.Model):
     perfil = models.CharField(max_length=50, choices=PERFILES)
     es_externo = models.BooleanField(default=False)
 
+    @property
+    def apellido(self):
+        """Return last name from linked user if available."""
+        return self.usuario.last_name if self.usuario else ""
+
+    @property
+    def nombre_completo(self):
+        """Convenience property for templates."""
+        if self.usuario and (self.usuario.first_name or self.usuario.last_name):
+            return f"{self.usuario.first_name} {self.usuario.last_name}".strip()
+        return self.nombre
+
     def __str__(self):
         return self.nombre
     

--- a/templates/tareas/detalle_orden_trabajo.html
+++ b/templates/tareas/detalle_orden_trabajo.html
@@ -66,40 +66,40 @@
 {% endif %}
             </td>
             {% if puede_asignar %}
-<td>
+            <td>
+            {% if not tarea.asignado_a and not tarea.agente_externo %}
 <form method="post" style="display:inline;">
   {% csrf_token %}
   <input type="hidden" name="tarea_id" value="{{ tarea.id }}">
 
-<!-- SELECT PRINCIPAL -->
-<select name="asignado_id" id="asignado_id{{ tarea.id }}" 
-        class="form-select form-select-sm d-inline w-auto"
-        onchange="checkTercerizado(this, '{{ tarea.id }}')">
+  <select name="asignado_id" id="asignado_id{{ tarea.id }}"
+          class="form-select form-select-sm d-inline w-auto"
+          onchange="checkTercerizado(this, '{{ tarea.id }}')">
     {% for operario in operarios %}
-        <option value="{{ operario.id }}" {% if tarea.asignado_a == operario %}selected{% endif %}>
-            {{ operario.nombre }} {{ operario.apellido }}
-        </option>
+      <option value="{{ operario.id }}" {% if tarea.asignado_a == operario %}selected{% endif %}>
+        {{ operario.nombre }} {{ operario.apellido }}
+      </option>
     {% endfor %}
-<option disabled>────────</option>
-<option value="tercerizado">Tercerizar</option>
-</select>
+    <option disabled>────────</option>
+    <option value="tercerizado">Tercerizar</option>
+  </select>
 
-<!-- SELECT AGENTE EXTERNO -->
-<div id="agente_externo_selector{{ tarea.id }}" style="display: none; margin-top: 5px;">
+  <div id="agente_externo_selector{{ tarea.id }}" style="display: none; margin-top: 5px;">
     <select name="agente_externo_id" class="form-select-sm d-inline w-auto">
-        {% for agente in agentes_externos %}
-            <option value="{{ agente.id }}">{{ agente.nombre }}</option>
-        {% endfor %}
+      {% for agente in agentes_externos %}
+        <option value="{{ agente.id }}">{{ agente.nombre }}</option>
+      {% endfor %}
     </select>
-</div>
+  </div>
 
-<!-- CAMPO OCULTO -->
-<input type="hidden" name="tipo_asignacion" id="tipo_asignacion_input{{ tarea.id }}" value="empleado">
+  <input type="hidden" name="tipo_asignacion" id="tipo_asignacion_input{{ tarea.id }}" value="empleado">
 
   <button type="submit" class="btn btn-sm btn-success">Asignar</button>
 </form>
+            {% else %}
+              <span class="text-muted">Asignada</span>
+            {% endif %}
 
-</td>
             </td>
             {% endif %}
             {% if perfil_usuario == 'ingenieria' or perfil_usuario == 'administrador' %}


### PR DESCRIPTION
## Summary
- expose `apellido` and `nombre_completo` helpers on `Empleado`
- hide assignment form once a task has someone assigned
- show employee name and surname in assignment dropdown

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68713b3cf738832fa1e50a0e04509305