### PR TITLE
Mostrar nombres y habilitar reasignación

### DIFF
--- a/tareas_app/models.py
+++ b/tareas_app/models.py
@@ -37,6 +37,18 @@ class Empleado(models.Model):
     perfil = models.CharField(max_length=50, choices=PERFILES)
     es_externo = models.BooleanField(default=False)
 
+    @property
+    def apellido(self):
+        """Return last name from linked user if available."""
+        return self.usuario.last_name if self.usuario else ""
+
+    @property
+    def nombre_completo(self):
+        """Convenience property for templates."""
+        if self.usuario and (self.usuario.first_name or self.usuario.last_name):
+            return f"{self.usuario.first_name} {self.usuario.last_name}".strip()
+        return self.nombre
+
     def __str__(self):
         return self.nombre
     

--- a/templates/tareas/detalle_orden_trabajo.html
+++ b/templates/tareas/detalle_orden_trabajo.html
@@ -66,40 +66,40 @@
 {% endif %}
             </td>
             {% if puede_asignar %}
-<td>
+            <td>
+            {% if not tarea.asignado_a and not tarea.agente_externo %}
 <form method="post" style="display:inline;">
   {% csrf_token %}
   <input type="hidden" name="tarea_id" value="{{ tarea.id }}">
 
-<!-- SELECT PRINCIPAL -->
-<select name="asignado_id" id="asignado_id{{ tarea.id }}" 
-        class="form-select form-select-sm d-inline w-auto"
-        onchange="checkTercerizado(this, '{{ tarea.id }}')">
-    {% for operario in operarios %}
+  <select name="asignado_id" id="asignado_id{{ tarea.id }}"
+          class="form-select form-select-sm d-inline w-auto"
+          onchange="checkTercerizado(this, '{{ tarea.id }}')">
+      {% for operario in operarios %}
         <option value="{{ operario.id }}" {% if tarea.asignado_a == operario %}selected{% endif %}>
-            {{ operario.nombre }} {{ operario.apellido }}
+          {{ operario.nombre_completo }}
         </option>
-    {% endfor %}
-<option disabled>────────</option>
-<option value="tercerizado">Tercerizar</option>
-</select>
+      {% endfor %}
+    <option disabled>────────</option>
+    <option value="tercerizado">Tercerizar</option>
+  </select>
 
-<!-- SELECT AGENTE EXTERNO -->
-<div id="agente_externo_selector{{ tarea.id }}" style="display: none; margin-top: 5px;">
+  <div id="agente_externo_selector{{ tarea.id }}" style="display: none; margin-top: 5px;">
     <select name="agente_externo_id" class="form-select-sm d-inline w-auto">
-        {% for agente in agentes_externos %}
-            <option value="{{ agente.id }}">{{ agente.nombre }}</option>
-        {% endfor %}
+      {% for agente in agentes_externos %}
+        <option value="{{ agente.id }}">{{ agente.nombre }}</option>
+      {% endfor %}
     </select>
-</div>
+  </div>
 
-<!-- CAMPO OCULTO -->
-<input type="hidden" name="tipo_asignacion" id="tipo_asignacion_input{{ tarea.id }}" value="empleado">
+  <input type="hidden" name="tipo_asignacion" id="tipo_asignacion_input{{ tarea.id }}" value="empleado">
 
   <button type="submit" class="btn btn-sm btn-success">Asignar</button>
 </form>
+            {% else %}
+              <span class="text-muted">Asignada</span>
+            {% endif %}
 
-</td>
             </td>
             {% endif %}
             {% if perfil_usuario == 'ingenieria' or perfil_usuario == 'administrador' %}

--- a/templates/tareas/detalle_tarea.html
+++ b/templates/tareas/detalle_tarea.html
@@ -6,7 +6,15 @@
         <div class="card-body">
             <h3 class="card-title">{{ tarea.titulo }}</h3>
             <p class="card-text"><strong>Descripción:</strong> {{ tarea.descripcion }}</p>
-            <p class="card-text"><strong>Asignado a:</strong> {{ tarea.asignado_a }}</p>
+            <p class="card-text"><strong>Asignado a:</strong>
+                {% if tarea.asignado_a %}
+                    {{ tarea.asignado_a.nombre_completo }}
+                {% elif tarea.agente_externo %}
+                    {{ tarea.agente_externo.nombre }} <span class="badge bg-secondary">Externo</span>
+                {% else %}
+                    <span class="text-muted">Sin asignar</span>
+                {% endif %}
+            </p>
             <p class="card-text"><strong>Creado por:</strong> {{ tarea.creada_por }}</p>
             <p class="card-text"><strong>Estado actual:</strong> 
                 <span class="badge bg-primary">{{ tarea.estado }}</span>
@@ -39,6 +47,42 @@
                 <button type="submit" name="accion" value="aceptar" class="btn btn-success">✅ Aceptar</button>
                 <button type="submit" name="accion" value="rechazar" class="btn btn-danger">❌ Rechazar</button>
             </form>
+            {% endif %}
+
+            {% if puede_asignar %}
+            <form method="post" class="mt-3">
+                {% csrf_token %}
+                <input type="hidden" name="accion" value="reasignar">
+                <select name="asignado_id" class="form-select form-select-sm d-inline w-auto" onchange="detCheckTercerizado(this)">
+                    {% for operario in operarios %}
+                        <option value="{{ operario.id }}" {% if tarea.asignado_a == operario %}selected{% endif %}>{{ operario.nombre_completo }}</option>
+                    {% endfor %}
+                    <option disabled>────────</option>
+                    <option value="tercerizado">Tercerizar</option>
+                </select>
+                <div id="detalle_externo_selector" style="display:none; margin-top:5px;">
+                    <select name="agente_externo_id" class="form-select-sm d-inline w-auto">
+                        {% for agente in agentes_externos %}
+                            <option value="{{ agente.id }}" {% if tarea.agente_externo == agente %}selected{% endif %}>{{ agente.nombre }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <input type="hidden" id="detalle_tipo_asignacion" name="tipo_asignacion" value="empleado">
+                <button type="submit" class="btn btn-sm btn-primary mt-2">Reasignar</button>
+            </form>
+            <script>
+            function detCheckTercerizado(sel){
+                const tipo = document.getElementById('detalle_tipo_asignacion');
+                const ext = document.getElementById('detalle_externo_selector');
+                if(sel.value === 'tercerizado'){
+                    tipo.value = 'tercerizado';
+                    ext.style.display = 'inline-block';
+                } else {
+                    tipo.value = 'empleado';
+                    ext.style.display = 'none';
+                }
+            }
+            </script>
             {% endif %}
 
         </div>


### PR DESCRIPTION
## Summary
- save employee full name when registering users or workshop staff
- show full names in assignment dropdowns
- allow reassignment from task detail with employee/external options

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68713b3cf738832fa1e50a0e04509305